### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KiZach/blazorapp/security/code-scanning/4](https://github.com/KiZach/blazorapp/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/deploy.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For the shown build-only workflow, the minimal safe baseline is:

- `contents: read`

Place this block after the `on:` section and before `jobs:`. No imports, methods, or additional definitions are needed (YAML config only). This preserves existing functionality while documenting and enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
